### PR TITLE
Increase max bind udp packet size

### DIFF
--- a/bin/delv/delv.c
+++ b/bin/delv/delv.c
@@ -596,9 +596,11 @@ key_fromconfig(const cfg_obj_t *key, dns_client_t *client) {
 	dns_rdata_ds_t ds;
 	uint32_t rdata1, rdata2, rdata3;
 	const char *datastr = NULL, *keynamestr = NULL, *atstr = NULL;
-	unsigned char data[4096];
+	// OQS updated from 4096 to 8192
+	unsigned char data[8192];
 	isc_buffer_t databuf;
-	unsigned char rrdata[4096];
+	// OQS updated from 4096 to 8192
+	unsigned char rrdata[8192];
 	isc_buffer_t rrdatabuf;
 	isc_region_t r;
 	dns_fixedname_t fkeyname;

--- a/bin/dig/dighost.c
+++ b/bin/dig/dighost.c
@@ -2802,7 +2802,8 @@ start_tcp(dig_query_t *query) {
 					     query, local_timeout, 0,
 					     query->tlsctx);
 		} else if (query->lookup->https_mode) {
-			char uri[4096] = { 0 };
+			// OQS updated from 4096 to 8192
+			char uri[8192] = { 0 };
 			snprintf(uri, sizeof(uri), "https://%s:%u%s",
 				 query->userarg, (uint16_t)port,
 				 query->lookup->https_path);

--- a/bin/dig/host.c
+++ b/bin/dig/host.c
@@ -212,7 +212,8 @@ printsection(dns_message_t *msg, dns_section_t sectionid,
 	isc_result_t result, loopresult;
 	isc_region_t r;
 	dns_name_t empty_name;
-	char tbuf[4096];
+	// OQS updated from 4096 to 8192
+	char tbuf[8192];
 	bool first;
 	bool no_rdata;
 
@@ -338,7 +339,8 @@ printrdata(dns_message_t *msg, dns_rdataset_t *rdataset,
 	isc_buffer_t target;
 	isc_result_t result;
 	isc_region_t r;
-	char tbuf[4096];
+	// OQS updated from 4096 to 8192
+	char tbuf[8192];
 
 	UNUSED(msg);
 	if (headers) {

--- a/bin/named/config.c
+++ b/bin/named/config.c
@@ -83,7 +83,7 @@ options {\n\
 	memstatistics-file \"named.memstats\";\n\
 #	multiple-cnames <obsolete>;\n\
 #	named-xfer <obsolete>;\n\
-	nocookie-udp-size 8192;\n\
+	nocookie-udp-size 8192;\n/*OQS updated from 4096*/\
 	notify-rate 20;\n\
 	nta-lifetime 3600;\n\
 	nta-recheck 300;\n\

--- a/bin/named/config.c
+++ b/bin/named/config.c
@@ -83,7 +83,7 @@ options {\n\
 	memstatistics-file \"named.memstats\";\n\
 #	multiple-cnames <obsolete>;\n\
 #	named-xfer <obsolete>;\n\
-	nocookie-udp-size 4096;\n\
+	nocookie-udp-size 8192;\n\
 	notify-rate 20;\n\
 	nta-lifetime 3600;\n\
 	nta-recheck 300;\n\

--- a/bin/named/fuzz.c
+++ b/bin/named/fuzz.c
@@ -111,10 +111,11 @@ fuzz_thread_client(void *arg) {
 			goto next;
 		}
 
+		// OQS updated from 4096 to 8192
 		/*
-		 * Ignore packets that are larger than 4096 bytes.
+		 * Ignore packets that are larger than 8192 bytes.
 		 */
-		if (length > 4096) {
+		if (length > 8192) {
 			/*
 			 * AFL_CMIN doesn't support persistent mode, so
 			 * shutdown the server.
@@ -364,7 +365,8 @@ fuzz_thread_resolver(void *arg) {
 			continue;
 		}
 
-		if (length > 4096) {
+		// OQS updated from 4096 to 8192
+		if (length > 8192) {
 			if (getenv("AFL_CMIN")) {
 				free(buf);
 				free(rbuf);

--- a/bin/named/main.c
+++ b/bin/named/main.c
@@ -129,7 +129,8 @@ LIBDNS_EXTERNAL_DATA extern unsigned int dns_zone_mkey_month;
 static bool want_stats = false;
 static char program_name[NAME_MAX] = "named";
 static char absolute_conffile[PATH_MAX];
-static char saved_command_line[4096] = { 0 };
+// OQS updated from 4096 to 8192
+static char saved_command_line[8192] = { 0 };
 static char ellipsis[5] = { 0 };
 static char version[512];
 static unsigned int maxsocks = 0;

--- a/bin/named/server.c
+++ b/bin/named/server.c
@@ -692,9 +692,11 @@ ta_fromconfig(const cfg_obj_t *key, bool *initialp, const char **namestrp,
 	dns_rdata_t rdata = DNS_RDATA_INIT;
 	uint32_t rdata1, rdata2, rdata3;
 	const char *datastr = NULL, *namestr = NULL;
-	unsigned char data[4096];
+	// OQS updated from 4096 to 8192
+	unsigned char data[8192];
 	isc_buffer_t databuf;
-	unsigned char rrdata[4096];
+	// OQS updated from 4096 to 8192
+	unsigned char rrdata[8192];
 	isc_buffer_t rrdatabuf;
 	isc_region_t r;
 	dns_fixedname_t fname;
@@ -1340,7 +1342,8 @@ get_view_querysource_dispatch(const cfg_obj_t **maps, int af,
 
 	disp = NULL;
 	result = dns_dispatch_getudp(named_g_dispatchmgr, named_g_socketmgr,
-				     named_g_taskmgr, &sa, 4096,
+				     // OQS updated from 4096 to 8192
+				     named_g_taskmgr, &sa, 8192,
 				     maxdispatchbuffers, 32768, 16411, 16433,
 				     attrs, attrmask, &disp);
 	if (result != ISC_R_SUCCESS) {
@@ -4850,8 +4853,9 @@ configure_view(dns_view_t *view, dns_viewlist_t *viewlist, cfg_obj_t *config,
 	if (udpsize < 512) {
 		udpsize = 512;
 	}
-	if (udpsize > 4096) {
-		udpsize = 4096;
+	// OQS updated from 4096 to 8192
+	if (udpsize > 8192) {
+		udpsize = 8192;
 	}
 	dns_resolver_setudpsize(view->resolver, (uint16_t)udpsize);
 
@@ -4865,8 +4869,9 @@ configure_view(dns_view_t *view, dns_viewlist_t *viewlist, cfg_obj_t *config,
 	if (udpsize < 512) {
 		udpsize = 512;
 	}
-	if (udpsize > 4096) {
-		udpsize = 4096;
+	// OQS updated from 4096 to 8192
+	if (udpsize > 8192) {
+		udpsize = 8192;
 	}
 	view->maxudp = udpsize;
 
@@ -8864,25 +8869,28 @@ load_configuration(const char *filename, named_server_t *server,
 	result = named_config_get(maps, "tcp-receive-buffer", &obj);
 	INSIST(result == ISC_R_SUCCESS);
 	recv_tcp_buffer_size = cfg_obj_asuint32(obj);
-	CAP_IF_NOT_ZERO(recv_tcp_buffer_size, 4096, INT32_MAX);
+	// OQS updated from 4096 to 8192
+	CAP_IF_NOT_ZERO(recv_tcp_buffer_size, 8192, INT32_MAX);
 
 	obj = NULL;
 	result = named_config_get(maps, "tcp-send-buffer", &obj);
 	INSIST(result == ISC_R_SUCCESS);
 	send_tcp_buffer_size = cfg_obj_asuint32(obj);
-	CAP_IF_NOT_ZERO(send_tcp_buffer_size, 4096, INT32_MAX);
+	// OQS updated from 4096 to 8192
+	CAP_IF_NOT_ZERO(send_tcp_buffer_size, 8192, INT32_MAX);
 
 	obj = NULL;
 	result = named_config_get(maps, "udp-receive-buffer", &obj);
 	INSIST(result == ISC_R_SUCCESS);
 	recv_udp_buffer_size = cfg_obj_asuint32(obj);
-	CAP_IF_NOT_ZERO(recv_udp_buffer_size, 4096, INT32_MAX);
+	// OQS updated from 4096 to 8192
+	CAP_IF_NOT_ZERO(recv_udp_buffer_size, 8192, INT32_MAX);
 
 	obj = NULL;
 	result = named_config_get(maps, "udp-send-buffer", &obj);
 	INSIST(result == ISC_R_SUCCESS);
 	send_udp_buffer_size = cfg_obj_asuint32(obj);
-	CAP_IF_NOT_ZERO(send_udp_buffer_size, 4096, INT32_MAX);
+	CAP_IF_NOT_ZERO(send_udp_buffer_size, 8192, INT32_MAX);
 
 	isc_nm_setnetbuffers(named_g_netmgr, recv_tcp_buffer_size,
 			     send_tcp_buffer_size, recv_udp_buffer_size,
@@ -8968,8 +8976,9 @@ load_configuration(const char *filename, named_server_t *server,
 	if (udpsize < 512) {
 		udpsize = 512;
 	}
-	if (udpsize > 4096) {
-		udpsize = 4096;
+	// OQS updated from 4096 to 8192
+	if (udpsize > 8192) {
+		udpsize = 8192;
 	}
 	server->sctx->udpsize = (uint16_t)udpsize;
 
@@ -10520,7 +10529,8 @@ named_add_reserved_dispatch(named_server_t *server,
 	attrmask |= DNS_DISPATCHATTR_IPV6;
 
 	result = dns_dispatch_getudp(named_g_dispatchmgr, named_g_socketmgr,
-				     named_g_taskmgr, &dispatch->addr, 4096,
+				     // OQS updated from 4096 to 8192
+				     named_g_taskmgr, &dispatch->addr, 8192,
 				     UDPBUFFERS, 32768, 16411, 16433, attrs,
 				     attrmask, &dispatch->dispatch);
 	if (result != ISC_R_SUCCESS) {
@@ -15017,7 +15027,8 @@ named_server_dnssec(named_server_t *server, isc_lex_t *lex,
 	uint8_t algorithm = 0;
 	/* variables for -status */
 	bool status = false;
-	char output[4096];
+	// OQS updated from 4096 to 8192
+	char output[8192];
 	isc_stdtime_t now, when;
 	isc_time_t timenow, timewhen;
 	const char *dir;

--- a/bin/named/server.c
+++ b/bin/named/server.c
@@ -1514,8 +1514,9 @@ configure_peer(const cfg_obj_t *cpeer, isc_mem_t *mctx, dns_peer_t **peerp) {
 		if (udpsize < 512U) {
 			udpsize = 512U;
 		}
-		if (udpsize > 4096U) {
-			udpsize = 4096U;
+		// OQS changed from 4096 to 8192
+		if (udpsize > 8192U) {
+			udpsize = 8192U;
 		}
 		CHECK(dns_peer_setudpsize(peer, (uint16_t)udpsize));
 	}
@@ -1537,8 +1538,9 @@ configure_peer(const cfg_obj_t *cpeer, isc_mem_t *mctx, dns_peer_t **peerp) {
 		if (udpsize < 512U) {
 			udpsize = 512U;
 		}
-		if (udpsize > 4096U) {
-			udpsize = 4096U;
+		// OQS updated to 8192
+		if (udpsize > 8192) {
+			udpsize = 8192U;
 		}
 		CHECK(dns_peer_setmaxudp(peer, (uint16_t)udpsize));
 	}

--- a/contrib/dlz/modules/mysqldyn/dlz_mysqldyn_mod.c
+++ b/contrib/dlz/modules/mysqldyn/dlz_mysqldyn_mod.c
@@ -1180,7 +1180,8 @@ dlz_lookup(const char *zone, const char *name, void *dbdata,
 		}
 
 		while ((row = mysql_fetch_row(res)) != NULL) {
-			char host[1024], admin[1024], data[4096];
+			// OQS updated from 4096 to 8192
+			char host[1024], admin[1024], data[8192];
 			int ttl;
 
 			sscanf(row[7], "%d", &ttl);

--- a/lib/bind9/check.c
+++ b/lib/bind9/check.c
@@ -3733,7 +3733,8 @@ check_trust_anchor(const cfg_obj_t *key, bool managed, unsigned int *flagsp,
 	isc_result_t result = ISC_R_SUCCESS;
 	isc_result_t tresult;
 	uint32_t rdata1, rdata2, rdata3;
-	unsigned char data[4096];
+	// OQS updated from 4096 to 8192
+	unsigned char data[8192];
 	const char *atstr = NULL;
 	enum {
 		INIT_DNSKEY,

--- a/lib/dns/client.c
+++ b/lib/dns/client.c
@@ -231,7 +231,8 @@ getudpdispatch(int family, dns_dispatchmgr_t *dispatchmgr,
 		localaddr = &anyaddr;
 	}
 
-	buffersize = 4096;
+	// OQS updated from 4096 to 8192
+	buffersize = 8192;
 	maxbuffers = is_shared ? 1000 : 8;
 	maxrequests = 32768;
 	buckets = is_shared ? 16411 : 3;

--- a/lib/dns/dst_parse.c
+++ b/lib/dns/dst_parse.c
@@ -712,30 +712,20 @@ dst__privstruct_writefile(const dst_key_t *key, const dst_private_t *priv,
 	int major, minor;
 	mode_t mode;
 	int i, ret;
-	printf("priv is null?\n");
-	fflush(stdout);
 	REQUIRE(priv != NULL);
-	printf("0\n");
-	fflush(stdout);
 	ret = check_data(priv, dst_key_alg(key), false, key->external);
 	if (ret < 0) {
-		printf("check_data failed\n");
-		fflush(stdout);
 		return (DST_R_INVALIDPRIVATEKEY);
 	} else if (ret != ISC_R_SUCCESS) {
 		return (ret);
 	}
 
-	printf("1\n");
-	fflush(stdout);
 	isc_buffer_init(&b, filename, sizeof(filename));
 	result = dst_key_buildfilename(key, DST_TYPE_PRIVATE, directory, &b);
 	if (result != ISC_R_SUCCESS) {
-		printf("Failed dst_key_buildfilename\n");
 		return (result);
 	}
 
-	printf("2\n");
 	result = isc_file_mode(filename, &mode);
 	if (result == ISC_R_SUCCESS && mode != 0600) {
 		/* File exists; warn that we are changing its permissions */
@@ -749,32 +739,26 @@ dst__privstruct_writefile(const dst_key_t *key, const dst_private_t *priv,
 			      "a result of this operation.",
 			      filename, (unsigned int)mode);
 	}
-	printf("3\n");
 
 	if ((fp = fopen(filename, "w")) == NULL) {
-		printf("write error\n");
 		return (DST_R_WRITEERROR);
 	}
-	printf("4\n");
 
 	access = 0;
 	isc_fsaccess_add(ISC_FSACCESS_OWNER,
 			 ISC_FSACCESS_READ | ISC_FSACCESS_WRITE, &access);
 	(void)isc_fsaccess_set(filename, access);
 
-	printf("5\n");
 	dst_key_getprivateformat(key, &major, &minor);
 	if (major == 0 && minor == 0) {
 		major = DST_MAJOR_VERSION;
 		minor = DST_MINOR_VERSION;
 	}
-	printf("6\n");
 
 	/* XXXDCL return value should be checked for full filesystem */
 	fprintf(fp, "%s v%d.%d\n", PRIVATE_KEY_STR, major, minor);
 
 	fprintf(fp, "%s %u ", ALGORITHM_STR, dst_key_alg(key));
-	printf("Pre switch\n");
 
 	/* XXXVIX this switch statement is too sparse to gen a jump table. */
 	switch (dst_key_alg(key)) {
@@ -833,7 +817,6 @@ dst__privstruct_writefile(const dst_key_t *key, const dst_private_t *priv,
 		fprintf(fp, "(?)\n");
 		break;
 	}
-	printf("Pre for loop\n");
 	for (i = 0; i < priv->nelements; i++) {
 		const char *s;
 
@@ -851,7 +834,6 @@ dst__privstruct_writefile(const dst_key_t *key, const dst_private_t *priv,
 
 		fprintf(fp, "%s %.*s\n", s, (int)r.length, r.base);
 	}
-	printf("Post for loop\n");
 
 	if (key->external) {
 		fprintf(fp, "External:\n");
@@ -893,7 +875,6 @@ dst__privstruct_writefile(const dst_key_t *key, const dst_private_t *priv,
 	fflush(fp);
 	result = ferror(fp) ? DST_R_WRITEERROR : ISC_R_SUCCESS;
 	fclose(fp);
-	printf("Post result\n");
 	return (result);
 }
 

--- a/lib/dns/keytable.c
+++ b/lib/dns/keytable.c
@@ -450,7 +450,8 @@ dns_keytable_deletekey(dns_keytable_t *keytable, const dns_name_t *keyname,
 	dns_rbtnode_t *node = NULL;
 	dns_keynode_t *knode = NULL;
 	dns_rdata_t rdata = DNS_RDATA_INIT;
-	unsigned char data[4096], digest[DNS_DS_BUFFERSIZE];
+	// OQS updated from 4096 to 8192
+	unsigned char data[8192], digest[DNS_DS_BUFFERSIZE];
 	dns_rdata_ds_t ds;
 	isc_buffer_t b;
 
@@ -620,7 +621,8 @@ dns_keytable_dump(dns_keytable_t *keytable, FILE *fp) {
 	REQUIRE(VALID_KEYTABLE(keytable));
 	REQUIRE(fp != NULL);
 
-	isc_buffer_allocate(keytable->mctx, &text, 4096);
+	// OQS updated from 4096 to 8192
+	isc_buffer_allocate(keytable->mctx, &text, 8192);
 
 	result = dns_keytable_totext(keytable, &text);
 

--- a/lib/dns/message.c
+++ b/lib/dns/message.c
@@ -2078,7 +2078,6 @@ dns_message_rendersection(dns_message_t *msg, dns_section_t sectionid,
 
 				count = 0;
 				if (partial) {
-					printf("!+!+partial\n");
 					result = dns_rdataset_towirepartial(
 						rdataset, name, msg->cctx,
 						msg->buffer, msg->order,
@@ -2108,7 +2107,6 @@ dns_message_rendersection(dns_message_t *msg, dns_section_t sectionid,
 				 * to indicate where to continue from.
 				 */
 				if (partial && result == ISC_R_NOSPACE) {
-					printf("partial nospace\n");
 					msg->buffer->length += msg->reserved;
 					msg->counts[sectionid] += total;
 					return (result);

--- a/lib/dns/message.c
+++ b/lib/dns/message.c
@@ -1982,7 +1982,7 @@ dns_message_rendersection(dns_message_t *msg, dns_section_t sectionid,
 	 * Shrink the space in the buffer by the reserved amount.
 	 */
 	if (msg->buffer->length - msg->buffer->used < msg->reserved) {
-		printf("NO SPACE! length: %d used: %d reserver: %d\n", msg->buffer->length, msg->buffer-used, msg->reserved);
+		printf("NO SPACE! length: %d used: %d reserver: %d\n", msg->buffer->length, msg->buffer->used, msg->reserved);
 		fflush(stdout);
 		return (ISC_R_NOSPACE);
 	}

--- a/lib/dns/message.c
+++ b/lib/dns/message.c
@@ -2019,6 +2019,7 @@ dns_message_rendersection(dns_message_t *msg, dns_section_t sectionid,
 			total += count;
 			if (partial && result == ISC_R_NOSPACE) {
 				printf("lib/dns/message:2021 TC flag set\n");
+				fflush(stdout);
 				msg->flags |= DNS_MESSAGEFLAG_TC;
 				msg->buffer->length += msg->reserved;
 				msg->counts[sectionid] += total;
@@ -2026,6 +2027,7 @@ dns_message_rendersection(dns_message_t *msg, dns_section_t sectionid,
 			}
 			if (result == ISC_R_NOSPACE) {
 				printf("lib/dns/message:2027 TC flag set\n");
+				fflush(stdout);
 				msg->flags |= DNS_MESSAGEFLAG_TC;
 			}
 			if (result != ISC_R_SUCCESS) {

--- a/lib/dns/message.c
+++ b/lib/dns/message.c
@@ -1982,6 +1982,8 @@ dns_message_rendersection(dns_message_t *msg, dns_section_t sectionid,
 	 * Shrink the space in the buffer by the reserved amount.
 	 */
 	if (msg->buffer->length - msg->buffer->used < msg->reserved) {
+		printf("NO SPACE! length: %d used: %d reserver: %d\n", msg->buffer->length, msg->buffer-used, msg->reserved);
+		fflush(stdout);
 		return (ISC_R_NOSPACE);
 	}
 	msg->buffer->length -= msg->reserved;
@@ -2076,12 +2078,16 @@ dns_message_rendersection(dns_message_t *msg, dns_section_t sectionid,
 
 				count = 0;
 				if (partial) {
+					printf("partial result\n");
+					fflush(stdout);
 					result = dns_rdataset_towirepartial(
 						rdataset, name, msg->cctx,
 						msg->buffer, msg->order,
 						&msg->order_arg, rd_options,
 						&count, NULL);
 				} else {
+					printf("non-partial result\n");
+					fflush(stdout);
 					result = dns_rdataset_towiresorted(
 						rdataset, name, msg->cctx,
 						msg->buffer, msg->order,

--- a/lib/dns/message.c
+++ b/lib/dns/message.c
@@ -1982,8 +1982,6 @@ dns_message_rendersection(dns_message_t *msg, dns_section_t sectionid,
 	 * Shrink the space in the buffer by the reserved amount.
 	 */
 	if (msg->buffer->length - msg->buffer->used < msg->reserved) {
-		printf("NO SPACE! length: %d used: %d reserver: %d\n", msg->buffer->length, msg->buffer->used, msg->reserved);
-		fflush(stdout);
 		return (ISC_R_NOSPACE);
 	}
 	msg->buffer->length -= msg->reserved;
@@ -2020,16 +2018,12 @@ dns_message_rendersection(dns_message_t *msg, dns_section_t sectionid,
 			}
 			total += count;
 			if (partial && result == ISC_R_NOSPACE) {
-				printf("lib/dns/message:2021 TC flag set\n");
-				fflush(stdout);
 				msg->flags |= DNS_MESSAGEFLAG_TC;
 				msg->buffer->length += msg->reserved;
 				msg->counts[sectionid] += total;
 				return (result);
 			}
 			if (result == ISC_R_NOSPACE) {
-				printf("lib/dns/message:2027 TC flag set\n");
-				fflush(stdout);
 				msg->flags |= DNS_MESSAGEFLAG_TC;
 			}
 			if (result != ISC_R_SUCCESS) {

--- a/lib/dns/message.c
+++ b/lib/dns/message.c
@@ -2078,16 +2078,12 @@ dns_message_rendersection(dns_message_t *msg, dns_section_t sectionid,
 
 				count = 0;
 				if (partial) {
-					printf("partial result\n");
-					fflush(stdout);
 					result = dns_rdataset_towirepartial(
 						rdataset, name, msg->cctx,
 						msg->buffer, msg->order,
 						&msg->order_arg, rd_options,
 						&count, NULL);
 				} else {
-					printf("non-partial result\n");
-					fflush(stdout);
 					result = dns_rdataset_towiresorted(
 						rdataset, name, msg->cctx,
 						msg->buffer, msg->order,
@@ -2116,6 +2112,7 @@ dns_message_rendersection(dns_message_t *msg, dns_section_t sectionid,
 					return (result);
 				}
 				if (result != ISC_R_SUCCESS) {
+					printf("NOSPACE from rdataset_towiresorted\n");
 					INSIST(st.used < 65536);
 					dns_compress_rollback(
 						msg->cctx, (uint16_t)st.used);

--- a/lib/dns/message.c
+++ b/lib/dns/message.c
@@ -2106,7 +2106,6 @@ dns_message_rendersection(dns_message_t *msg, dns_section_t sectionid,
 					return (result);
 				}
 				if (result != ISC_R_SUCCESS) {
-					printf("NOSPACE from rdataset_towiresorted\n");
 					INSIST(st.used < 65536);
 					dns_compress_rollback(
 						msg->cctx, (uint16_t)st.used);

--- a/lib/dns/message.c
+++ b/lib/dns/message.c
@@ -2018,12 +2018,14 @@ dns_message_rendersection(dns_message_t *msg, dns_section_t sectionid,
 			}
 			total += count;
 			if (partial && result == ISC_R_NOSPACE) {
+				printf("lib/dns/message:2021 TC flag set\n");
 				msg->flags |= DNS_MESSAGEFLAG_TC;
 				msg->buffer->length += msg->reserved;
 				msg->counts[sectionid] += total;
 				return (result);
 			}
 			if (result == ISC_R_NOSPACE) {
+				printf("lib/dns/message:2027 TC flag set\n");
 				msg->flags |= DNS_MESSAGEFLAG_TC;
 			}
 			if (result != ISC_R_SUCCESS) {

--- a/lib/dns/message.c
+++ b/lib/dns/message.c
@@ -2078,6 +2078,7 @@ dns_message_rendersection(dns_message_t *msg, dns_section_t sectionid,
 
 				count = 0;
 				if (partial) {
+					printf("!+!+partial\n");
 					result = dns_rdataset_towirepartial(
 						rdataset, name, msg->cctx,
 						msg->buffer, msg->order,
@@ -2107,6 +2108,7 @@ dns_message_rendersection(dns_message_t *msg, dns_section_t sectionid,
 				 * to indicate where to continue from.
 				 */
 				if (partial && result == ISC_R_NOSPACE) {
+					printf("partial nospace\n");
 					msg->buffer->length += msg->reserved;
 					msg->counts[sectionid] += total;
 					return (result);

--- a/lib/dns/openssldilithium2_link.c
+++ b/lib/dns/openssldilithium2_link.c
@@ -381,17 +381,9 @@ openssldilithium2_tofile(const dst_key_t *key, const char *directory) {
 
 	if (openssldilithium2_isprivate(key)) {
 		privbuf = isc_mem_get(key->mctx, privlen);
-		if (privbuf == NULL) {
-			printf("Failed to get a privbuf\n");
-		}
 		OQS_KEY *oqs_key = EVP_PKEY_get0(key->keydata.pkey);
-		if (oqs_key == NULL) {
-			printf("oqs_key is null\n");
-		}
-		printf("privlen: %lu - %lu\n", privlen, oqs_key->s->length_secret_key);
 		if (EVP_PKEY_get_raw_private_key(key->keydata.pkey, privbuf,
 						 &privlen) != 1) {
-			printf("Failed to get raw private_key\n");
 			DST_RET(dst__openssl_toresult(ISC_R_FAILURE));
 		}
 		priv.elements[i].tag = TAG_DILITHIUM2_PRIVATEKEY;
@@ -399,12 +391,8 @@ openssldilithium2_tofile(const dst_key_t *key, const char *directory) {
 		priv.elements[i].data = privbuf;
 		i++;
 		pubbuf = isc_mem_get(key->mctx, publen);
-		if (pubbuf == NULL) {
-			printf("Failed to get a pubbuf\n");
-		}
 		if (EVP_PKEY_get_raw_public_key(key->keydata.pkey, pubbuf,
 						 &publen) != 1) {
-			printf("Failed to get raw public_key\n");
 			DST_RET(dst__openssl_toresult(ISC_R_FAILURE));
 		}
 		priv.elements[i].tag = TAG_DILITHIUM2_PUBLICKEY;
@@ -413,9 +401,7 @@ openssldilithium2_tofile(const dst_key_t *key, const char *directory) {
 		i++;
 	}
 	priv.nelements = i;
-	printf("pre-privstruct_writefile\n");
 	ret = dst__privstruct_writefile(key, &priv, directory);
-	printf("!=tofile ret = %d\n", ret);
 err:
 	if (privbuf != NULL) {
 		isc_mem_put(key->mctx, privbuf, privlen);

--- a/lib/dns/openssldilithium2_link.c
+++ b/lib/dns/openssldilithium2_link.c
@@ -381,7 +381,6 @@ openssldilithium2_tofile(const dst_key_t *key, const char *directory) {
 
 	if (openssldilithium2_isprivate(key)) {
 		privbuf = isc_mem_get(key->mctx, privlen);
-		OQS_KEY *oqs_key = EVP_PKEY_get0(key->keydata.pkey);
 		if (EVP_PKEY_get_raw_private_key(key->keydata.pkey, privbuf,
 						 &privlen) != 1) {
 			DST_RET(dst__openssl_toresult(ISC_R_FAILURE));

--- a/lib/dns/rdataset.c
+++ b/lib/dns/rdataset.c
@@ -360,9 +360,6 @@ towiresorted(dns_rdataset_t *rdataset, const dns_name_t *owner_name,
 			return (ISC_R_SUCCESS);
 		}
 		if (result != ISC_R_SUCCESS) {
-			if (result == ISC_R_NOSPACE) {
-				printf("!+!+!+!+!+!+rdataset_first\n");
-			}
 			return (result);
 		}
 	}
@@ -458,7 +455,6 @@ towiresorted(dns_rdataset_t *rdataset, const dns_name_t *owner_name,
 		dns_compress_setmethods(cctx, DNS_COMPRESS_GLOBAL14);
 		result = dns_name_towire2(name, cctx, target, &offset);
 		if (result != ISC_R_SUCCESS) {
-			printf("!+!+!+!+!+!+name_towrite2 NOSPACE\n");
 			goto rollback;
 		}
 		headlen = sizeof(dns_rdataclass_t) + sizeof(dns_rdatatype_t);
@@ -468,7 +464,6 @@ towiresorted(dns_rdataset_t *rdataset, const dns_name_t *owner_name,
 		   */
 		isc_buffer_availableregion(target, &r);
 		if (r.length < headlen) {
-			printf("NOSPACE r.length: %d, headlen: %d\n", r.length, headlen);
 			result = ISC_R_NOSPACE;
 			goto rollback;
 		}
@@ -496,9 +491,6 @@ towiresorted(dns_rdataset_t *rdataset, const dns_name_t *owner_name,
 			}
 			result = dns_rdata_towire(&rdata, cctx, target);
 			if (result != ISC_R_SUCCESS) {
-				if (result == ISC_R_NOSPACE) {
-					printf("!+!+!++!+rdata_towire NOSPACE\n");
-				}
 				goto rollback;
 			}
 			INSIST((target->used >= rdlen.used + 2) &&
@@ -518,9 +510,6 @@ towiresorted(dns_rdataset_t *rdataset, const dns_name_t *owner_name,
 			}
 		} else {
 			result = dns_rdataset_next(rdataset);
-			if (result == ISC_R_NOSPACE) {
-				printf("!+!+!++!+rdataset_next NOSPACE\n");
-			}
 		}
 	} while (result == ISC_R_SUCCESS);
 

--- a/lib/dns/rdataset.c
+++ b/lib/dns/rdataset.c
@@ -518,7 +518,7 @@ towiresorted(dns_rdataset_t *rdataset, const dns_name_t *owner_name,
 			}
 		} else {
 			result = dns_rdataset_next(rdataset);
-			if (result == USC_R_NOSPACE) {
+			if (result == ISC_R_NOSPACE) {
 				printf("!+!+!++!+rdataset_next NOSPACE\n");
 			}
 		}

--- a/lib/dns/rdataset.c
+++ b/lib/dns/rdataset.c
@@ -360,6 +360,9 @@ towiresorted(dns_rdataset_t *rdataset, const dns_name_t *owner_name,
 			return (ISC_R_SUCCESS);
 		}
 		if (result != ISC_R_SUCCESS) {
+			if (result == ISC_R_NOSPACE) {
+				printf("!+!+!+!+!+!+rdataset_first\n");
+			}
 			return (result);
 		}
 	}
@@ -455,6 +458,7 @@ towiresorted(dns_rdataset_t *rdataset, const dns_name_t *owner_name,
 		dns_compress_setmethods(cctx, DNS_COMPRESS_GLOBAL14);
 		result = dns_name_towire2(name, cctx, target, &offset);
 		if (result != ISC_R_SUCCESS) {
+			printf("!+!+!+!+!+!+name_towrite2 NOSPACE\n");
 			goto rollback;
 		}
 		headlen = sizeof(dns_rdataclass_t) + sizeof(dns_rdatatype_t);
@@ -464,6 +468,7 @@ towiresorted(dns_rdataset_t *rdataset, const dns_name_t *owner_name,
 		   */
 		isc_buffer_availableregion(target, &r);
 		if (r.length < headlen) {
+			printf("NOSPACE r.length: %d, headlen: %d\n", r.length, headlen);
 			result = ISC_R_NOSPACE;
 			goto rollback;
 		}
@@ -491,6 +496,9 @@ towiresorted(dns_rdataset_t *rdataset, const dns_name_t *owner_name,
 			}
 			result = dns_rdata_towire(&rdata, cctx, target);
 			if (result != ISC_R_SUCCESS) {
+				if (result == ISC_R_NOSPACE) {
+					printf("!+!+!++!+rdata_towire NOSPACE\n");
+				}
 				goto rollback;
 			}
 			INSIST((target->used >= rdlen.used + 2) &&
@@ -510,6 +518,9 @@ towiresorted(dns_rdataset_t *rdataset, const dns_name_t *owner_name,
 			}
 		} else {
 			result = dns_rdataset_next(rdataset);
+			if (result == USC_R_NOSPACE) {
+				printf("!+!+!++!+rdataset_next NOSPACE\n");
+			}
 		}
 	} while (result == ISC_R_SUCCESS);
 

--- a/lib/dns/request.c
+++ b/lib/dns/request.c
@@ -583,7 +583,8 @@ create_tcp_dispatch(bool newtcp, bool share, dns_requestmgr_t *requestmgr,
 	isc_socket_dscp(sock, dscp);
 	result = dns_dispatch_createtcp(
 		requestmgr->dispatchmgr, sock, requestmgr->taskmgr, srcaddr,
-		destaddr, 4096, 32768, 32768, 16411, 16433, attrs, dispatchp);
+		// OQS updated from 4096 to 8192
+		destaddr, 8192, 32768, 32768, 16411, 16433, attrs, dispatchp);
 cleanup:
 	isc_socket_detach(&sock);
 	return (result);
@@ -635,7 +636,8 @@ find_udp_dispatch(dns_requestmgr_t *requestmgr, const isc_sockaddr_t *srcaddr,
 	attrmask |= DNS_DISPATCHATTR_IPV6;
 	return (dns_dispatch_getudp(requestmgr->dispatchmgr,
 				    requestmgr->socketmgr, requestmgr->taskmgr,
-				    srcaddr, 4096, 32768, 32768, 16411, 16433,
+				    // OQS updated from 4096 to 8192
+				    srcaddr, 8192, 32768, 32768, 16411, 16433,
 				    attrs, attrmask, dispatchp));
 }
 

--- a/lib/dns/resolver.c
+++ b/lib/dns/resolver.c
@@ -201,7 +201,8 @@
 /*%
  * Maximum EDNS0 input packet size.
  */
-#define RECV_BUFFER_SIZE 4096 /* XXXRTH  Constant. */
+// OQS updated from 4096 to 8192
+#define RECV_BUFFER_SIZE 8192 /* XXXRTH  Constant. */
 
 /*%
  * Default EDNS0 buffer size
@@ -2180,7 +2181,8 @@ fctx_query(fetchctx_t *fctx, dns_adbaddrinfo_t *addrinfo,
 			attrmask |= DNS_DISPATCHATTR_IPV6;
 			result = dns_dispatch_getudp(
 				res->dispatchmgr, res->socketmgr, res->taskmgr,
-				&addr, 4096, 20000, 32768, 16411, 16433, attrs,
+				// OQS updated from 4096 to 8192
+				&addr, 8192, 20000, 32768, 16411, 16433, attrs,
 				attrmask, &query->dispatch);
 			if (result != ISC_R_SUCCESS) {
 				goto cleanup_query;
@@ -3046,7 +3048,8 @@ resquery_connected(isc_task_t *task, isc_event_t *event) {
 
 			result = dns_dispatch_createtcp(
 				query->dispatchmgr, query->tcpsocket,
-				query->fctx->res->taskmgr, NULL, NULL, 4096, 2,
+				// OQS updated from 4096 to 8192
+				query->fctx->res->taskmgr, NULL, NULL, 8192, 2,
 				1, 1, 3, attrs, &query->dispatch);
 
 			/*

--- a/lib/dns/update.c
+++ b/lib/dns/update.c
@@ -204,7 +204,8 @@ static void
 update_log(dns_update_log_t *callback, dns_zone_t *zone, int level,
 	   const char *fmt, ...) {
 	va_list ap;
-	char message[4096];
+	// OQS updated from 4096 to 8192
+	char message[8192];
 
 	if (callback == NULL) {
 		return;

--- a/lib/dns/zone.c
+++ b/lib/dns/zone.c
@@ -4059,7 +4059,8 @@ create_keydata(dns_zone_t *zone, dns_db_t *db, dns_dbversion_t *ver,
 	isc_result_t result = ISC_R_SUCCESS;
 	dns_rdata_t rdata = DNS_RDATA_INIT;
 	dns_rdata_keydata_t kd;
-	unsigned char rrdata[4096];
+	// OQS updated from 4096 to 8192
+	unsigned char rrdata[8192];
 	isc_buffer_t rrdatabuf;
 	isc_stdtime_t now;
 
@@ -4130,7 +4131,8 @@ compute_tag(dns_name_t *name, dns_rdata_dnskey_t *dnskey, isc_mem_t *mctx,
 	    dns_keytag_t *tag) {
 	isc_result_t result;
 	dns_rdata_t rdata = DNS_RDATA_INIT;
-	unsigned char data[4096];
+	// OQS updated from 4096 to 8192
+	unsigned char data[8192];
 	isc_buffer_t buffer;
 	dst_key_t *dstkey = NULL;
 
@@ -4155,7 +4157,8 @@ trust_key(dns_zone_t *zone, dns_name_t *keyname, dns_rdata_dnskey_t *dnskey,
 	  bool initial) {
 	isc_result_t result;
 	dns_rdata_t rdata = DNS_RDATA_INIT;
-	unsigned char data[4096], digest[ISC_MAX_MD_SIZE];
+	// OQS updated from 4096 to 8192
+	unsigned char data[8192], digest[ISC_MAX_MD_SIZE];
 	isc_buffer_t buffer;
 	dns_keytable_t *sr = NULL;
 	dns_rdata_ds_t ds;
@@ -9881,7 +9884,8 @@ normalize_key(dns_rdata_t *rr, dns_rdata_t *target, unsigned char *data,
 
 static bool
 matchkey(dns_rdataset_t *rdset, dns_rdata_t *rr) {
-	unsigned char data1[4096], data2[4096];
+	// OQS updated from 4096 to 8192
+	unsigned char data1[8192], data2[8192];
 	dns_rdata_t rdata, rdata1, rdata2;
 	isc_result_t result;
 
@@ -9996,7 +10000,8 @@ static isc_result_t
 minimal_update(dns_keyfetch_t *kfetch, dns_dbversion_t *ver, dns_diff_t *diff) {
 	isc_result_t result;
 	isc_buffer_t keyb;
-	unsigned char key_buf[4096];
+	// OQS updated from 4096 to 8192
+	unsigned char key_buf[8192];
 	dns_rdata_t rdata = DNS_RDATA_INIT;
 	dns_rdata_keydata_t keydata;
 	dns_name_t *name;
@@ -10056,7 +10061,8 @@ revocable(dns_keyfetch_t *kfetch, dns_rdata_keydata_t *keydata) {
 	dns_rdata_rrsig_t sig;
 	dns_rdata_dnskey_t dnskey;
 	dst_key_t *dstkey = NULL;
-	unsigned char key_buf[4096];
+	// OQS updated from 4096 to 8192
+	unsigned char key_buf[8192];
 	isc_buffer_t keyb;
 	bool answer = false;
 
@@ -10136,7 +10142,8 @@ keyfetch_done(isc_task_t *task, isc_event_t *event) {
 	dns_rdata_keydata_t keydata;
 	bool initializing;
 	char namebuf[DNS_NAME_FORMATSIZE];
-	unsigned char key_buf[4096];
+	// OQS updated from 4096 to 8192
+	unsigned char key_buf[8192];
 	isc_buffer_t keyb;
 	dst_key_t *dstkey = NULL;
 	isc_stdtime_t now;
@@ -15654,7 +15661,8 @@ dns_zone_nameonly(dns_zone_t *zone, char *buf, size_t length) {
 void
 dns_zone_logv(dns_zone_t *zone, isc_logcategory_t *category, int level,
 	      const char *prefix, const char *fmt, va_list ap) {
-	char message[4096];
+	// OQS updated from 4096 to 8192
+	char message[8192];
 	const char *zstr;
 
 	REQUIRE(DNS_ZONE_VALID(zone));

--- a/lib/isccc/include/isccc/cc.h
+++ b/lib/isccc/include/isccc/cc.h
@@ -49,7 +49,8 @@ ISC_LANG_BEGINDECLS
 #define ISCCC_ALG_HMACSHA512 165
 
 /*% Maximum Datagram Package */
-#define ISCCC_CC_MAXDGRAMPACKET 4096
+// OQS updated from 4096 to 8192
+#define ISCCC_CC_MAXDGRAMPACKET 8192
 
 /*% Message Type String */
 #define ISCCC_CCMSGTYPE_STRING 0x00

--- a/lib/ns/client.c
+++ b/lib/ns/client.c
@@ -496,6 +496,7 @@ ns_client_send(ns_client_t *client) {
 	result = dns_message_rendersection(client->message,
 					   DNS_SECTION_QUESTION, 0);
 	if (result == ISC_R_NOSPACE) {
+		printf("lib/ns/client.c:499 TC flag set\n");
 		client->message->flags |= DNS_MESSAGEFLAG_TC;
 		goto renderend;
 	}
@@ -512,6 +513,7 @@ ns_client_send(ns_client_t *client) {
 					   DNS_MESSAGERENDER_PARTIAL |
 						   render_opts);
 	if (result == ISC_R_NOSPACE) {
+		printf("lib/ns/client.c:515 TC flag set\n");
 		client->message->flags |= DNS_MESSAGEFLAG_TC;
 		goto renderend;
 	}
@@ -522,6 +524,7 @@ ns_client_send(ns_client_t *client) {
 		client->message, DNS_SECTION_AUTHORITY,
 		DNS_MESSAGERENDER_PARTIAL | render_opts);
 	if (result == ISC_R_NOSPACE) {
+		printf("lib/ns/client.c:525 TC flag set\n");
 		client->message->flags |= DNS_MESSAGEFLAG_TC;
 		goto renderend;
 	}

--- a/lib/ns/client.c
+++ b/lib/ns/client.c
@@ -497,6 +497,7 @@ ns_client_send(ns_client_t *client) {
 					   DNS_SECTION_QUESTION, 0);
 	if (result == ISC_R_NOSPACE) {
 		printf("lib/ns/client.c:499 TC flag set\n");
+		fflush(stdout);
 		client->message->flags |= DNS_MESSAGEFLAG_TC;
 		goto renderend;
 	}
@@ -514,6 +515,7 @@ ns_client_send(ns_client_t *client) {
 						   render_opts);
 	if (result == ISC_R_NOSPACE) {
 		printf("lib/ns/client.c:515 TC flag set\n");
+		fflush(stdout);
 		client->message->flags |= DNS_MESSAGEFLAG_TC;
 		goto renderend;
 	}
@@ -525,6 +527,7 @@ ns_client_send(ns_client_t *client) {
 		DNS_MESSAGERENDER_PARTIAL | render_opts);
 	if (result == ISC_R_NOSPACE) {
 		printf("lib/ns/client.c:525 TC flag set\n");
+		fflush(stdout);
 		client->message->flags |= DNS_MESSAGEFLAG_TC;
 		goto renderend;
 	}

--- a/lib/ns/client.c
+++ b/lib/ns/client.c
@@ -284,6 +284,8 @@ client_allocsendbuf(ns_client_t *client, isc_buffer_t *buffer,
 		data = client->sendbuf;
 		if ((client->attributes & NS_CLIENTATTR_HAVECOOKIE) == 0) {
 			if (client->view != NULL) {
+				printf("Nocookie udp: %d\n", client->view->nocookieudp);
+				fflush(stdout);
 				bufsize = client->view->nocookieudp;
 			} else {
 				bufsize = 512;

--- a/lib/ns/client.c
+++ b/lib/ns/client.c
@@ -284,8 +284,6 @@ client_allocsendbuf(ns_client_t *client, isc_buffer_t *buffer,
 		data = client->sendbuf;
 		if ((client->attributes & NS_CLIENTATTR_HAVECOOKIE) == 0) {
 			if (client->view != NULL) {
-				printf("Nocookie udp: %d\n", client->view->nocookieudp);
-				fflush(stdout);
 				bufsize = client->view->nocookieudp;
 			} else {
 				bufsize = 512;
@@ -498,8 +496,6 @@ ns_client_send(ns_client_t *client) {
 	result = dns_message_rendersection(client->message,
 					   DNS_SECTION_QUESTION, 0);
 	if (result == ISC_R_NOSPACE) {
-		printf("lib/ns/client.c:499 TC flag set\n");
-		fflush(stdout);
 		client->message->flags |= DNS_MESSAGEFLAG_TC;
 		goto renderend;
 	}
@@ -516,8 +512,6 @@ ns_client_send(ns_client_t *client) {
 					   DNS_MESSAGERENDER_PARTIAL |
 						   render_opts);
 	if (result == ISC_R_NOSPACE) {
-		printf("lib/ns/client.c:515 TC flag set\n");
-		fflush(stdout);
 		client->message->flags |= DNS_MESSAGEFLAG_TC;
 		goto renderend;
 	}
@@ -528,8 +522,6 @@ ns_client_send(ns_client_t *client) {
 		client->message, DNS_SECTION_AUTHORITY,
 		DNS_MESSAGERENDER_PARTIAL | render_opts);
 	if (result == ISC_R_NOSPACE) {
-		printf("lib/ns/client.c:525 TC flag set\n");
-		fflush(stdout);
 		client->message->flags |= DNS_MESSAGEFLAG_TC;
 		goto renderend;
 	}

--- a/lib/ns/client.c
+++ b/lib/ns/client.c
@@ -2526,7 +2526,8 @@ void
 ns_client_logv(ns_client_t *client, isc_logcategory_t *category,
 	       isc_logmodule_t *module, int level, const char *fmt,
 	       va_list ap) {
-	char msgbuf[4096];
+	// OQS updated from 4096 to 8192
+	char msgbuf[8192];
 	char signerbuf[DNS_NAME_FORMATSIZE], qnamebuf[DNS_NAME_FORMATSIZE];
 	char peerbuf[ISC_SOCKADDR_FORMATSIZE];
 	const char *viewname = "";

--- a/lib/ns/include/ns/client.h
+++ b/lib/ns/include/ns/client.h
@@ -82,7 +82,8 @@
  ***/
 
 #define NS_CLIENT_TCP_BUFFER_SIZE  65535
-#define NS_CLIENT_SEND_BUFFER_SIZE 4096
+// OQS updated from 4096 to 8192
+#define NS_CLIENT_SEND_BUFFER_SIZE 8192
 
 /*!
  * Client object states.  Ordering is significant: higher-numbered

--- a/lib/ns/query.c
+++ b/lib/ns/query.c
@@ -7225,6 +7225,7 @@ query_checkrpz(query_ctx_t *qctx, isc_result_t result) {
 		switch (qctx->rpz_st->m.policy) {
 		case DNS_RPZ_POLICY_TCP_ONLY:
 			printf("lib/ns/query.c:7227 TC set\n");
+			fflush(stdout);
 			qctx->client->message->flags |= DNS_MESSAGEFLAG_TC;
 			if (result == DNS_R_NXDOMAIN ||
 			    result == DNS_R_NCACHENXDOMAIN) {

--- a/lib/ns/query.c
+++ b/lib/ns/query.c
@@ -7224,6 +7224,7 @@ query_checkrpz(query_ctx_t *qctx, isc_result_t result) {
 
 		switch (qctx->rpz_st->m.policy) {
 		case DNS_RPZ_POLICY_TCP_ONLY:
+			printf("lib/ns/query.c:7227 TC set\n");
 			qctx->client->message->flags |= DNS_MESSAGEFLAG_TC;
 			if (result == DNS_R_NXDOMAIN ||
 			    result == DNS_R_NCACHENXDOMAIN) {

--- a/lib/ns/update.c
+++ b/lib/ns/update.c
@@ -272,7 +272,8 @@ static void
 update_log(ns_client_t *client, dns_zone_t *zone, int level, const char *fmt,
 	   ...) {
 	va_list ap;
-	char message[4096];
+	// OQS updated from 4096 to 8192
+	char message[8192];
 	char namebuf[DNS_NAME_FORMATSIZE];
 	char classbuf[DNS_RDATACLASS_FORMATSIZE];
 


### PR DESCRIPTION
This PR increases the max UDP size bind can send from 4096 to 8192.