### PR TITLE
Fix dsfromkey

### DIFF
--- a/bin/dnssec/Makefile.am
+++ b/bin/dnssec/Makefile.am
@@ -49,3 +49,13 @@ dnssec_signzone_LDADD =		\
 	$(LDADD)		\
 	$(LIBISCCFG_LIBS)	\
 	$(OPENSSL_LIBS)
+
+dnssec_dsfromkey_CPPFLAGS =	\
+	$(AM_CPPFLAGS)		\
+	$(LIBISCCFG_CFLAGS)	\
+	$(OPENSSL_CFLAGS)
+
+dnssec_dsfromkey_LDADD =	\
+	$(LDADD)		\
+	$(LIBISCCFG_LIBS)	\
+	$(OPENSSL_LIBS)

--- a/bin/dnssec/dnssec-dsfromkey.c
+++ b/bin/dnssec/dnssec-dsfromkey.c
@@ -374,8 +374,7 @@ main(int argc, char **argv) {
 	dns_rdataset_t rdataset;
 	dns_rdata_t rdata;
 #if OPENSSL_VERSION_NUMBER >= 0x30200000L && OPENSSL_API_LEVEL >= 30200
-	OSSL_PROVIDER *base = NULL, *oqs = NULL,
-		      *default_provider = NULL;
+	OSSL_PROVIDER *oqs = NULL, *default_provider = NULL;
 #endif
 
 	dns_rdata_init(&rdata);
@@ -464,14 +463,8 @@ main(int argc, char **argv) {
 		}
 	}
 #if OPENSSL_VERSION_NUMBER >= 0x30200000L && OPENSSL_API_LEVEL >= 30200
-	oqs = OSSL_PROVIDER_load(NULL, "oqsprovider");
+	oqs = OSSL_PROVIDER_load(NULL, "oqsprovider") {
 	if (oqs == NULL) {
-		if (fips != NULL) {
-			OSSL_PROVIDER_unload(fips);
-		}
-		if (base != NULL) {
-			OSSL_PROVIDER_unload(base);
-		}
 		ERR_print_errors_fp(stderr);
 		ERR_clear_error();
 		fatal("Failed to load oqsprovider");
@@ -568,6 +561,14 @@ main(int argc, char **argv) {
 		emits(showall, cds, &rdata);
 	}
 
+#if OPENSSL_VERSION_NUMBER >= 0x30200000L && OPENSSL_API_LEVEL >= 30200
+	if (oqs != NULL) {
+		OSSL_PROVIDER_unload(oqs);
+	}
+	if (default_provider != NULL) {
+		OSSL_PROVIDER_unload(default_provider);
+	}
+#endif
 	if (dns_rdataset_isassociated(&rdataset)) {
 		dns_rdataset_disassociate(&rdataset);
 	}

--- a/bin/dnssec/dnssec-dsfromkey.c
+++ b/bin/dnssec/dnssec-dsfromkey.c
@@ -462,7 +462,7 @@ main(int argc, char **argv) {
 			exit(1);
 		}
 	}
-	printf("before Loading providers\N");
+	printf("before Loading providers\n");
 #if OPENSSL_VERSION_NUMBER >= 0x30200000L && OPENSSL_API_LEVEL >= 30200
 	printf("Loading providers\N");
 	oqs = OSSL_PROVIDER_load(OSSL_LIB_CTX_get0_global_default(), "oqsprovider") {

--- a/bin/dnssec/dnssec-dsfromkey.c
+++ b/bin/dnssec/dnssec-dsfromkey.c
@@ -463,6 +463,7 @@ main(int argc, char **argv) {
 		}
 	}
 #if OPENSSL_VERSION_NUMBER >= 0x30200000L && OPENSSL_API_LEVEL >= 30200
+	printf("Loading providers\N");
 	oqs = OSSL_PROVIDER_load(OSSL_LIB_CTX_get0_global_default(), "oqsprovider") {
 	if (oqs == NULL) {
 		ERR_print_errors_fp(stderr);

--- a/bin/dnssec/dnssec-dsfromkey.c
+++ b/bin/dnssec/dnssec-dsfromkey.c
@@ -466,8 +466,8 @@ main(int argc, char **argv) {
 	}
 	printf("before Loading providers\n");
 #if OPENSSL_VERSION_NUMBER >= 0x30200000L && OPENSSL_API_LEVEL >= 30200
-	printf("Loading providers\N");
-	oqs = OSSL_PROVIDER_load(OSSL_LIB_CTX_get0_global_default(), "oqsprovider") {
+	printf("Loading providers\n");
+	oqs = OSSL_PROVIDER_load(OSSL_LIB_CTX_get0_global_default(), "oqsprovider");
 	if (oqs == NULL) {
 		ERR_print_errors_fp(stderr);
 		ERR_clear_error();

--- a/bin/dnssec/dnssec-dsfromkey.c
+++ b/bin/dnssec/dnssec-dsfromkey.c
@@ -464,9 +464,7 @@ main(int argc, char **argv) {
 			exit(1);
 		}
 	}
-	printf("before Loading providers\n");
 #if OPENSSL_VERSION_NUMBER >= 0x30200000L && OPENSSL_API_LEVEL >= 30200
-	printf("Loading providers\n");
 	oqs = OSSL_PROVIDER_load(OSSL_LIB_CTX_get0_global_default(), "oqsprovider");
 	if (oqs == NULL) {
 		ERR_print_errors_fp(stderr);

--- a/bin/dnssec/dnssec-dsfromkey.c
+++ b/bin/dnssec/dnssec-dsfromkey.c
@@ -462,6 +462,7 @@ main(int argc, char **argv) {
 			exit(1);
 		}
 	}
+	printf("before Loading providers\N");
 #if OPENSSL_VERSION_NUMBER >= 0x30200000L && OPENSSL_API_LEVEL >= 30200
 	printf("Loading providers\N");
 	oqs = OSSL_PROVIDER_load(OSSL_LIB_CTX_get0_global_default(), "oqsprovider") {

--- a/bin/dnssec/dnssec-dsfromkey.c
+++ b/bin/dnssec/dnssec-dsfromkey.c
@@ -463,15 +463,16 @@ main(int argc, char **argv) {
 		}
 	}
 #if OPENSSL_VERSION_NUMBER >= 0x30200000L && OPENSSL_API_LEVEL >= 30200
-	oqs = OSSL_PROVIDER_load(NULL, "oqsprovider") {
+	oqs = OSSL_PROVIDER_load(OSSL_LIB_CTX_get0_global_default(), "oqsprovider") {
 	if (oqs == NULL) {
 		ERR_print_errors_fp(stderr);
 		ERR_clear_error();
 		fatal("Failed to load oqsprovider");
 	}
-	default_provider = OSSL_PROVIDER_load(NULL, "default");
+	default_provider = OSSL_PROVIDER_load(OSSL_LIB_CTX_get0_global_default(), "default");
 	if (default_provider == NULL) {
 		OSSL_PROVIDER_unload(oqs);
+		ERR_print_errors_fp(stderr);
 		ERR_clear_error();
 		fatal("Failed to load default provider");
 	}

--- a/bin/dnssec/dnssec-dsfromkey.c
+++ b/bin/dnssec/dnssec-dsfromkey.c
@@ -17,6 +17,8 @@
 #include <stdbool.h>
 #include <stdlib.h>
 
+#include <openssl/opensslv.h>
+
 #include <isc/attributes.h>
 #include <isc/buffer.h>
 #include <isc/commandline.h>

--- a/bin/dnssec/dnssec-keygen.c
+++ b/bin/dnssec/dnssec-keygen.c
@@ -1176,7 +1176,7 @@ main(int argc, char **argv) {
 		}
 	}
 #if OPENSSL_VERSION_NUMBER >= 0x30200000L && OPENSSL_API_LEVEL >= 30200
-	oqs = OSSL_PROVIDER_load(NULL, "oqsprovider");
+	oqs = OSSL_PROVIDER_load(OSSL_LIB_CTX_get0_global_default(), "oqsprovider");
 	if (oqs == NULL) {
 		if (fips != NULL) {
 			OSSL_PROVIDER_unload(fips);
@@ -1188,7 +1188,7 @@ main(int argc, char **argv) {
 		ERR_clear_error();
 		fatal("Failed to load oqsprovider");
 	}
-	default_provider = OSSL_PROVIDER_load(NULL, "default");
+	default_provider = OSSL_PROVIDER_load(OSSL_LIB_CTX_get0_global_default(), "default");
 	if (default_provider == NULL) {
 		OSSL_PROVIDER_unload(oqs);
 		ERR_clear_error();

--- a/bin/dnssec/dnssec-signzone.c
+++ b/bin/dnssec/dnssec-signzone.c
@@ -3739,12 +3739,12 @@ main(int argc, char *argv[]) {
 
 	if (set_fips_mode) {
 #if OPENSSL_VERSION_NUMBER >= 0x30200000L && OPENSSL_API_LEVEL >= 30200
-		fips = OSSL_PROVIDER_load(NULL, "fips");
+		fips = OSSL_PROVIDER_load(OSSL_LIB_CTX_get0_global_default(), "fips");
 		if (fips == NULL) {
 			ERR_clear_error();
 			fatal("Failed to load FIPS provider");
 		}
-		base = OSSL_PROVIDER_load(NULL, "base");
+		base = OSSL_PROVIDER_load(OSSL_LIB_CTX_get0_global_default(), "base");
 		if (base == NULL) {
 			OSSL_PROVIDER_unload(fips);
 			ERR_clear_error();
@@ -3758,7 +3758,7 @@ main(int argc, char *argv[]) {
 		}
 	}
 #if OPENSSL_VERSION_NUMBER >= 0x30200000L && OPENSSL_API_LEVEL >= 30200
-	oqs = OSSL_PROVIDER_load(NULL, "oqsprovider");
+	oqs = OSSL_PROVIDER_load(OSSL_LIB_CTX_get0_global_default(), "oqsprovider");
 	if (oqs == NULL) {
 		if (fips != NULL) {
 			OSSL_PROVIDER_unload(fips);

--- a/lib/dns/openssloqs_link.c
+++ b/lib/dns/openssloqs_link.c
@@ -115,17 +115,19 @@ raw_pub_key_to_ossl(const oqs_alginfo_t *alginfo, const unsigned char *pub_key,
 
 	if (pub_key != NULL) {
 		if (pub_key_len == NULL) {
+			printf("Failed pub_keyLen\n");
 			return (ret);
 		}
 		*pkey = EVP_PKEY_new_raw_public_key_ex(
 			NULL, alg_name, NULL, pub_key, *pub_key_len);
 	}
 	if (*pkey == NULL) {
+		printf("*pkey==NULL\n");
 		return (dst__openssl_toresult(ret));
 	}
-	*pub_key_len = alginfo->key_size;
 	return (ISC_R_SUCCESS);
 }
+
 static isc_result_t
 raw_priv_key_to_ossl(const oqs_alginfo_t *alginfo,
 		     const unsigned char *priv_key, size_t *priv_key_len,

--- a/lib/dns/openssloqs_link.c
+++ b/lib/dns/openssloqs_link.c
@@ -122,7 +122,8 @@ raw_pub_key_to_ossl(const oqs_alginfo_t *alginfo, const unsigned char *pub_key,
 			NULL, alg_name, NULL, pub_key, *pub_key_len);
 	}
 	if (*pkey == NULL) {
-		printf("*pkey==NULL\n");
+		printf("*pkey==NULL: %s\n", );
+		ERR_print_errors_fp(stderr);
 		return (dst__openssl_toresult(ret));
 	}
 	return (ISC_R_SUCCESS);

--- a/lib/dns/openssloqs_link.c
+++ b/lib/dns/openssloqs_link.c
@@ -115,7 +115,6 @@ raw_pub_key_to_ossl(const oqs_alginfo_t *alginfo, const unsigned char *pub_key,
 
 	if (pub_key != NULL) {
 		if (pub_key_len == NULL) {
-			printf("Failed pub_keyLen\n");
 			return (ret);
 		}
 		*pkey = EVP_PKEY_new_raw_public_key_ex(
@@ -123,7 +122,6 @@ raw_pub_key_to_ossl(const oqs_alginfo_t *alginfo, const unsigned char *pub_key,
 			alg_name, NULL, pub_key, *pub_key_len);
 	}
 	if (*pkey == NULL) {
-		printf("*pkey==NULL\n");
 		ERR_print_errors_fp(stderr);
 		return (dst__openssl_toresult(ret));
 	}

--- a/lib/dns/openssloqs_link.c
+++ b/lib/dns/openssloqs_link.c
@@ -119,7 +119,8 @@ raw_pub_key_to_ossl(const oqs_alginfo_t *alginfo, const unsigned char *pub_key,
 			return (ret);
 		}
 		*pkey = EVP_PKEY_new_raw_public_key_ex(
-			NULL, alg_name, NULL, pub_key, *pub_key_len);
+			OSSL_LIB_CTX_get0_global_default(), 
+			alg_name, NULL, pub_key, *pub_key_len);
 	}
 	if (*pkey == NULL) {
 		printf("*pkey==NULL\n");

--- a/lib/dns/openssloqs_link.c
+++ b/lib/dns/openssloqs_link.c
@@ -122,7 +122,7 @@ raw_pub_key_to_ossl(const oqs_alginfo_t *alginfo, const unsigned char *pub_key,
 			NULL, alg_name, NULL, pub_key, *pub_key_len);
 	}
 	if (*pkey == NULL) {
-		printf("*pkey==NULL: %s\n", );
+		printf("*pkey==NULL\n");
 		ERR_print_errors_fp(stderr);
 		return (dst__openssl_toresult(ret));
 	}


### PR DESCRIPTION
This PR resolves the issue where oqsprovider wasn't being loaded for `dnssec-dsfromkey`